### PR TITLE
added a per attempt time limit

### DIFF
--- a/src/main/java/com/github/rholder/retry/AttemptTimeLimiter.java
+++ b/src/main/java/com/github/rholder/retry/AttemptTimeLimiter.java
@@ -1,0 +1,17 @@
+package com.github.rholder.retry;
+
+import java.util.concurrent.Callable;
+
+/**
+ * A rule to wrap any single attempt in a time limit, where it will possibly be interrupted if the limit is exceeded.
+ * @param <V> return type of Callable
+ *
+ * @author Jason Dunkelberger (dirkraft)
+ */
+public interface AttemptTimeLimiter<V> {
+    /**
+     * @param callable to subject to the time limit
+     * @return the return of the given callable
+     */
+    V call(Callable<V> callable) throws Exception;
+}

--- a/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
+++ b/src/main/java/com/github/rholder/retry/AttemptTimeLimiters.java
@@ -1,0 +1,89 @@
+package com.github.rholder.retry;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.TimeLimiter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.Immutable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Factory class for instances of {@link AttemptTimeLimiter}
+ * @author Jason Dunkelberger (dirkraft)
+ */
+public class AttemptTimeLimiters {
+
+    private AttemptTimeLimiters(){
+    }
+
+    /**
+     * @return an {@link AttemptTimeLimiter} impl which has no time limit
+     */
+    public static <V> AttemptTimeLimiter<V> noTimeLimit() {
+        return new NoAttemptTimeLimit<V>();
+    }
+
+    /**
+     * For control over thread management, it is preferable to offer an {@link ExecutorService} through the other
+     * factory method, {@link #fixedTimeLimit(long, TimeUnit, ExecutorService)}. See the note on
+     * {@link SimpleTimeLimiter#SimpleTimeLimiter(ExecutorService)}, which this AttemptTimeLimiter uses.
+     * @param duration that an attempt may persist before being circumvented
+     * @param timeUnit of the 'duration' arg
+     * @return an {@link AttemptTimeLimiter} with a fixed time limit for each attempt
+     */
+    public static <V> AttemptTimeLimiter<V> fixedTimeLimit(long duration, @Nonnull TimeUnit timeUnit) {
+        Preconditions.checkNotNull(timeUnit);
+        return new FixedAttemptTimeLimit<V>(duration, timeUnit);
+    }
+
+    /**
+     * @param duration that an attempt may persist before being circumvented
+     * @param timeUnit of the 'duration' arg
+     * @param executorService used to enforce time limit
+     * @return an {@link AttemptTimeLimiter} with a fixed time limit for each attempt
+     */
+    public static <V> AttemptTimeLimiter<V> fixedTimeLimit(long duration, @Nonnull TimeUnit timeUnit, @Nonnull ExecutorService executorService) {
+        Preconditions.checkNotNull(timeUnit);
+        return new FixedAttemptTimeLimit<V>(duration, timeUnit, executorService);
+    }
+
+    @Immutable
+    private static final class NoAttemptTimeLimit<V> implements AttemptTimeLimiter<V> {
+        @Override
+        public V call(Callable<V> callable) throws Exception {
+            return callable.call();
+        }
+    }
+
+    @Immutable
+    private static final class FixedAttemptTimeLimit<V> implements AttemptTimeLimiter<V> {
+
+        private final TimeLimiter timeLimiter;
+        private final long duration;
+        private final TimeUnit timeUnit;
+
+        public FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit) {
+            this(new SimpleTimeLimiter(), duration, timeUnit);
+        }
+
+        public FixedAttemptTimeLimit(long duration, @Nonnull TimeUnit timeUnit, @Nonnull ExecutorService executorService) {
+            this(new SimpleTimeLimiter(executorService), duration, timeUnit);
+        }
+
+        private FixedAttemptTimeLimit(@Nonnull TimeLimiter timeLimiter, long duration, @Nonnull TimeUnit timeUnit) {
+            Preconditions.checkNotNull(timeLimiter);
+            Preconditions.checkNotNull(timeUnit);
+            this.timeLimiter = timeLimiter;
+            this.duration = duration;
+            this.timeUnit = timeUnit;
+        }
+
+        @Override
+        public V call(Callable<V> callable) throws Exception {
+            return timeLimiter.callWithTimeout(callable, duration, timeUnit, true);
+        }
+    }
+}

--- a/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
+++ b/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
@@ -1,0 +1,52 @@
+package com.github.rholder.retry;
+
+import com.google.common.util.concurrent.UncheckedTimeoutException;
+import junit.framework.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Jason Dunkelberger (dirkraft)
+ */
+public class AttemptTimeLimiterTest {
+
+    Retryer<Void> r = RetryerBuilder.<Void>newBuilder()
+            .withAttemptTimeLimiter(AttemptTimeLimiters.<Void>fixedTimeLimit(1, TimeUnit.SECONDS))
+            .build();
+
+    @Test
+    public void testAttemptTimeLimit() throws ExecutionException, RetryException {
+        try {
+            r.call(new SleepyOut(0L));
+        } catch (ExecutionException e) {
+            Assert.fail("Should not timeout");
+        }
+
+        try {
+            r.call(new SleepyOut(10 * 1000L));
+            Assert.fail("Expected timeout exception");
+        } catch (ExecutionException e) {
+            // expected
+            Assert.assertEquals(UncheckedTimeoutException.class, e.getCause().getClass());
+        }
+    }
+
+    static class SleepyOut implements Callable<Void> {
+
+        final long sleepMs;
+
+        SleepyOut(long sleepMs) {
+            this.sleepMs = sleepMs;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            Thread.sleep(sleepMs);
+            System.out.println("I'm awake now");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This provides a mechanism to limit any one single attempt from clobbering a Retryer.
- Combined with StopStrategies.stopAfterAttempt, it is easier to approximate the max run time.
- Combined with StopStrategies.stopAfterDelay, it is possible to ensure that some minimum number of attempts were made in the allotted total delay window.
