### PR TITLE
Add Java 8 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
-
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
   - openjdk6


### PR DESCRIPTION
Because more Java can't be bad… can it?
