### PR TITLE
Fix JUnit imports in AttemptTimeLimiterTest

### DIFF
--- a/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
+++ b/src/test/java/com/github/rholder/retry/AttemptTimeLimiterTest.java
@@ -17,7 +17,7 @@
 package com.github.rholder.retry;
 
 import com.google.common.util.concurrent.UncheckedTimeoutException;
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.Callable;


### PR DESCRIPTION
The import from deprecated package `junit.framework.*` caused a deprecation warning.
