### PR TITLE
Adding block strategies to the retryer to decide how to block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ out
 *.iml
 *.ipr
 *.iws
-gradle.properties
+gradle.properties.DS_Store
+classes/
+gradle/.DS_STORE
+local.properties

--- a/src/main/java/com/github/rholder/retry/BlockStrategies.java
+++ b/src/main/java/com/github/rholder/retry/BlockStrategies.java
@@ -1,0 +1,18 @@
+package com.github.rholder.retry;
+
+public class BlockStrategies {
+    private static final BlockStrategy THREAD_SLEEP_STRATEGY = new ThreadSleepStrategy();
+
+
+    public static BlockStrategy threadSleepStrategy() {
+        return THREAD_SLEEP_STRATEGY;
+    }
+
+    private static class ThreadSleepStrategy implements BlockStrategy {
+
+			@Override
+            public void block(long sleepTime) throws InterruptedException {
+                Thread.sleep(sleepTime);
+            }
+    }
+}

--- a/src/main/java/com/github/rholder/retry/BlockStrategy.java
+++ b/src/main/java/com/github/rholder/retry/BlockStrategy.java
@@ -1,0 +1,7 @@
+package com.github.rholder.retry;
+
+public interface BlockStrategy {
+	
+    void block(long sleepTime) throws InterruptedException;
+
+}

--- a/src/test/java/com/github/rholder/retry/RetryerBuilderTest.java
+++ b/src/test/java/com/github/rholder/retry/RetryerBuilderTest.java
@@ -19,7 +19,11 @@ package com.github.rholder.retry;
 import com.github.rholder.retry.Retryer.RetryerCallable;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
+import com.google.common.util.concurrent.UncheckedTimeoutException;
+
+import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -27,11 +31,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.times;
 
 public class RetryerBuilderTest {
 
@@ -76,6 +82,27 @@ public class RetryerBuilderTest {
         catch (RetryException e) {
             assertEquals(3, e.getNumberOfFailedAttempts());
         }
+    }
+
+    @Test
+    public void testWithBlockStrategy() throws ExecutionException, RetryException {
+        Callable<Boolean> callable = notNullAfter5Attempts();
+        final AtomicInteger counter = new AtomicInteger();
+        BlockStrategy blockStrategy = new BlockStrategy() {
+            @Override
+            public void block(long sleepTime) throws InterruptedException {
+                counter.incrementAndGet();
+            }
+        };
+
+        Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
+                                                 .withBlockStrategy(blockStrategy)
+                                                 .retryIfResult(Predicates.<Boolean>isNull())
+                                                 .build();
+        final int retryCount = 5;
+        boolean result = retryer.call(callable);
+        assertTrue(result);
+        assertEquals(counter.get(), retryCount);
     }
 
     @Test


### PR DESCRIPTION
Allowed for different implementations of blocking to provide an alternative to Thread.sleep(). WIth a block strategy, you can block with any other concurrency mechanism. This allowed us to block using a countdown latch so that we can block and retry on demand.
