### PR TITLE
Fix for issue #30

### DIFF
--- a/src/main/java/com/github/rholder/retry/StopStrategies.java
+++ b/src/main/java/com/github/rholder/retry/StopStrategies.java
@@ -16,6 +16,9 @@
 
 package com.github.rholder.retry;
 
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 import com.google.common.base.Preconditions;
@@ -61,9 +64,27 @@ public final class StopStrategies {
      *
      * @param delayInMillis the delay, in milliseconds, starting from first attempt
      * @return a stop strategy which stops after {@code delayInMillis} time in milliseconds
+     * @deprecated Use {@link #stopAfterDelay(long, TimeUnit)} instead.
      */
+    @Deprecated
     public static StopStrategy stopAfterDelay(long delayInMillis) {
-        return new StopAfterDelayStrategy(delayInMillis);
+        return stopAfterDelay(delayInMillis, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Returns a stop strategy which stops after a given delay. If an
+     * unsuccessful attempt is made, this {@link StopStrategy} will check if the
+     * amount of time that's passed from the first attempt has exceeded the
+     * given delay amount. If it has exceeded this delay, then using this
+     * strategy causes the retrying to stop.
+     *
+     * @param duration the delay, starting from first attempt
+     * @param timeUnit the unit of the duration
+     * @return a stop strategy which stops after {@code delayInMillis} time in milliseconds
+     */
+    public static StopStrategy stopAfterDelay(long duration, @Nonnull TimeUnit timeUnit) {
+        Preconditions.checkNotNull(timeUnit, "The time unit may not be null");
+        return new StopAfterDelayStrategy(timeUnit.toMillis(duration));
     }
 
     @Immutable

--- a/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
+++ b/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
@@ -19,6 +19,8 @@ package com.github.rholder.retry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.Test;
 
 public class StopStrategiesTest {
@@ -36,10 +38,16 @@ public class StopStrategiesTest {
     }
 
     @Test
-    public void testStopAfterDelay() {
+    public void testStopAfterDelayWithMilliseconds() {
         assertFalse(StopStrategies.stopAfterDelay(1000L).shouldStop(2, 999L));
-        assertTrue(StopStrategies.stopAfterDelay(3).shouldStop(2, 1000L));
-        assertTrue(StopStrategies.stopAfterDelay(3).shouldStop(2, 1001L));
+        assertTrue(StopStrategies.stopAfterDelay(1000L).shouldStop(2, 1000L));
+        assertTrue(StopStrategies.stopAfterDelay(1000L).shouldStop(2, 1001L));
     }
 
+    @Test
+    public void testStopAfterDelayWithTimeUnit() {
+        assertFalse(StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS).shouldStop(2, 999L));
+        assertTrue(StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS).shouldStop(2, 1000L));
+        assertTrue(StopStrategies.stopAfterDelay(1, TimeUnit.SECONDS).shouldStop(2, 1001L));
+    }
 }


### PR DESCRIPTION
From the commit message:

    Introduce StopStrategies#stopAfterDelay(long, TimeUnit).
    
    For consistency with the AttemptTimeLimiters and WaitStrategies classes,
    StopStrategies now also accepts (long, TimeUnit) pairs. The original method has
    been deprecated in favor of its new overload.
    
    The unit test for the now-deprecated method was fixed and a unit test for the
    new method was added.

Other than that all I can say is that I tried to stay as close as possible to the existing coding style. Let me know if you feel further changes are required.