### PR TITLE
Return builder from a Retryer instance

### DIFF
--- a/src/main/java/com/github/rholder/retry/Retryer.java
+++ b/src/main/java/com/github/rholder/retry/Retryer.java
@@ -49,6 +49,7 @@ public final class Retryer<V> {
     private final AttemptTimeLimiter<V> attemptTimeLimiter;
     private final Predicate<Attempt<V>> rejectionPredicate;
     private final Collection<RetryListener> listeners;
+    private final RetryerBuilder<V> retryerBuilder;
 
     /**
      * Constructor
@@ -99,7 +100,7 @@ public final class Retryer<V> {
                    @Nonnull WaitStrategy waitStrategy,
                    @Nonnull BlockStrategy blockStrategy,
                    @Nonnull Predicate<Attempt<V>> rejectionPredicate) {
-        this(attemptTimeLimiter, stopStrategy, waitStrategy, blockStrategy, rejectionPredicate, new ArrayList<RetryListener>());
+        this(attemptTimeLimiter, stopStrategy, waitStrategy, blockStrategy, rejectionPredicate, new ArrayList<RetryListener>(), null);
     }
 
     /**
@@ -120,6 +121,30 @@ public final class Retryer<V> {
                    @Nonnull BlockStrategy blockStrategy,
                    @Nonnull Predicate<Attempt<V>> rejectionPredicate,
                    @Nonnull Collection<RetryListener> listeners) {
+        this(attemptTimeLimiter, stopStrategy, waitStrategy, blockStrategy, rejectionPredicate, listeners, null);
+    }
+
+
+    /**
+     * Constructor
+     *
+     * @param attemptTimeLimiter to prevent from any single attempt from spinning infinitely
+     * @param stopStrategy       the strategy used to decide when the retryer must stop retrying
+     * @param waitStrategy       the strategy used to decide how much time to sleep between attempts
+     * @param blockStrategy      the strategy used to decide how to block between retry attempts; eg, Thread#sleep(), latches, etc.
+     * @param rejectionPredicate the predicate used to decide if the attempt must be rejected
+     *                           or not. If an attempt is rejected, the retryer will retry the call, unless the stop
+     *                           strategy indicates otherwise or the thread is interrupted.
+     * @param listeners          collection of retry listeners
+     * @param retryerBuilder     the builder used to create this instance, may be null
+     */
+    public Retryer(@Nonnull AttemptTimeLimiter<V> attemptTimeLimiter,
+                   @Nonnull StopStrategy stopStrategy,
+                   @Nonnull WaitStrategy waitStrategy,
+                   @Nonnull BlockStrategy blockStrategy,
+                   @Nonnull Predicate<Attempt<V>> rejectionPredicate,
+                   @Nonnull Collection<RetryListener> listeners,
+                   RetryerBuilder<V> retryerBuilder) {
         Preconditions.checkNotNull(attemptTimeLimiter, "timeLimiter may not be null");
         Preconditions.checkNotNull(stopStrategy, "stopStrategy may not be null");
         Preconditions.checkNotNull(waitStrategy, "waitStrategy may not be null");
@@ -133,6 +158,7 @@ public final class Retryer<V> {
         this.blockStrategy = blockStrategy;
         this.rejectionPredicate = rejectionPredicate;
         this.listeners = listeners;
+        this.retryerBuilder = retryerBuilder;
     }
 
     /**
@@ -192,6 +218,16 @@ public final class Retryer<V> {
      */
     public RetryerCallable<V> wrap(Callable<V> callable) {
         return new RetryerCallable<V>(this, callable);
+    }
+
+    /**
+     * Return the {@link RetryerBuilder} used to create this {@link Retryer}
+     * instance or null if no builder was used.
+     *
+     * @return the original {@link RetryerBuilder} used to create this instance
+     */
+    public RetryerBuilder<V> getRetryerBuilder() {
+        return retryerBuilder;
     }
 
     @Immutable

--- a/src/main/java/com/github/rholder/retry/RetryerBuilder.java
+++ b/src/main/java/com/github/rholder/retry/RetryerBuilder.java
@@ -193,7 +193,7 @@ public class RetryerBuilder<V> {
         WaitStrategy theWaitStrategy = waitStrategy == null ? WaitStrategies.noWait() : waitStrategy;
         BlockStrategy theBlockStrategy = blockStrategy == null ? BlockStrategies.threadSleepStrategy() : blockStrategy;
 
-        return new Retryer<V>(theAttemptTimeLimiter, theStopStrategy, theWaitStrategy, theBlockStrategy, rejectionPredicate, listeners);
+        return new Retryer<V>(theAttemptTimeLimiter, theStopStrategy, theWaitStrategy, theBlockStrategy, rejectionPredicate, listeners, this);
     }
 
     private static final class ExceptionClassPredicate<V> implements Predicate<Attempt<V>> {


### PR DESCRIPTION
This returns the `RetryerBuilder` used to build the `Retryer` instance, if it exists, as described in #13. In adding this functionality, I noticed a few things that I believe make this feature less desirable.

The builder itself doesn't currently expose methods for inspecting the existing configured strategies so we'd need to add those which increases the public API footprint. Resetting the strategies upon inspection and then mutation (for the returned original builder) is currently not possible because of the `checkState` guards on most of the setters. We'd need to relax those checks to complete the use case described in #13 (or maybe expose another mechanism for safely returning/cloning and mutating in a single step?).

I am open to exploring other means of completing #13 than what I've created here or further expanding on this if there is still interest. In the mean time, I'm adding this as a PR such that I can continue moving a 2.x release forward without worrying about trying to get this feature completed before that ships.