### PR TITLE
Changing the version range for guava to be strictly maven compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:[10.+,)'
+    compile 'com.google.guava:guava:[10.0,)'
     compile 'com.google.code.findbugs:jsr305:2.0.2'
 
     // junit testing


### PR DESCRIPTION
The use of '+' in the range isn't strictly supported by maven and
can cause issues if using a private repository manager that validates
the requests (specifically jfrogs artifactory).
