### PR TITLE
Make ExceptionAttempt and ResultAttempt public

### DIFF
--- a/src/main/java/com/github/rholder/retry/ExceptionAttempt.java
+++ b/src/main/java/com/github/rholder/retry/ExceptionAttempt.java
@@ -1,0 +1,53 @@
+package com.github.rholder.retry;
+
+import java.util.concurrent.ExecutionException;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public final class ExceptionAttempt<R> implements Attempt<R> {
+    private final ExecutionException e;
+    private final long attemptNumber;
+    private final long delaySinceFirstAttempt;
+
+    public ExceptionAttempt(Throwable cause, long attemptNumber, long delaySinceFirstAttempt) {
+        this.e = new ExecutionException(cause);
+        this.attemptNumber = attemptNumber;
+        this.delaySinceFirstAttempt = delaySinceFirstAttempt;
+    }
+
+    @Override
+    public R get() throws ExecutionException {
+        throw e;
+    }
+
+    @Override
+    public boolean hasResult() {
+        return false;
+    }
+
+    @Override
+    public boolean hasException() {
+        return true;
+    }
+
+    @Override
+    public R getResult() throws IllegalStateException {
+        throw new IllegalStateException("The attempt resulted in an exception, not in a result");
+    }
+
+    @Override
+    public Throwable getExceptionCause() throws IllegalStateException {
+        return e.getCause();
+    }
+
+    @Override
+    public long getAttemptNumber() {
+        return attemptNumber;
+    }
+
+    @Override
+    public long getDelaySinceFirstAttempt() {
+        return delaySinceFirstAttempt;
+    }
+}

--- a/src/main/java/com/github/rholder/retry/ResultAttempt.java
+++ b/src/main/java/com/github/rholder/retry/ResultAttempt.java
@@ -1,0 +1,53 @@
+package com.github.rholder.retry;
+
+import java.util.concurrent.ExecutionException;
+
+import javax.annotation.concurrent.Immutable;
+
+@Immutable
+public final class ResultAttempt<R> implements Attempt<R> {
+    private final R result;
+    private final long attemptNumber;
+    private final long delaySinceFirstAttempt;
+
+    public ResultAttempt(R result, long attemptNumber, long delaySinceFirstAttempt) {
+        this.result = result;
+        this.attemptNumber = attemptNumber;
+        this.delaySinceFirstAttempt = delaySinceFirstAttempt;
+    }
+
+    @Override
+    public R get() throws ExecutionException {
+        return result;
+    }
+
+    @Override
+    public boolean hasResult() {
+        return true;
+    }
+
+    @Override
+    public boolean hasException() {
+        return false;
+    }
+
+    @Override
+    public R getResult() throws IllegalStateException {
+        return result;
+    }
+
+    @Override
+    public Throwable getExceptionCause() throws IllegalStateException {
+        throw new IllegalStateException("The attempt resulted in a result, not in an exception");
+    }
+
+    @Override
+    public long getAttemptNumber() {
+        return attemptNumber;
+    }
+
+    @Override
+    public long getDelaySinceFirstAttempt() {
+        return delaySinceFirstAttempt;
+    }
+}

--- a/src/main/java/com/github/rholder/retry/Retryer.java
+++ b/src/main/java/com/github/rholder/retry/Retryer.java
@@ -21,7 +21,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 
 import javax.annotation.Nonnull;
-import javax.annotation.concurrent.Immutable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.Callable;
@@ -194,102 +193,6 @@ public final class Retryer<V> {
      */
     public RetryerCallable<V> wrap(Callable<V> callable) {
         return new RetryerCallable<V>(this, callable);
-    }
-
-    @Immutable
-    static final class ResultAttempt<R> implements Attempt<R> {
-        private final R result;
-        private final long attemptNumber;
-        private final long delaySinceFirstAttempt;
-
-        public ResultAttempt(R result, long attemptNumber, long delaySinceFirstAttempt) {
-            this.result = result;
-            this.attemptNumber = attemptNumber;
-            this.delaySinceFirstAttempt = delaySinceFirstAttempt;
-        }
-
-        @Override
-        public R get() throws ExecutionException {
-            return result;
-        }
-
-        @Override
-        public boolean hasResult() {
-            return true;
-        }
-
-        @Override
-        public boolean hasException() {
-            return false;
-        }
-
-        @Override
-        public R getResult() throws IllegalStateException {
-            return result;
-        }
-
-        @Override
-        public Throwable getExceptionCause() throws IllegalStateException {
-            throw new IllegalStateException("The attempt resulted in a result, not in an exception");
-        }
-
-        @Override
-        public long getAttemptNumber() {
-            return attemptNumber;
-        }
-
-        @Override
-        public long getDelaySinceFirstAttempt() {
-            return delaySinceFirstAttempt;
-        }
-    }
-
-    @Immutable
-    static final class ExceptionAttempt<R> implements Attempt<R> {
-        private final ExecutionException e;
-        private final long attemptNumber;
-        private final long delaySinceFirstAttempt;
-
-        public ExceptionAttempt(Throwable cause, long attemptNumber, long delaySinceFirstAttempt) {
-            this.e = new ExecutionException(cause);
-            this.attemptNumber = attemptNumber;
-            this.delaySinceFirstAttempt = delaySinceFirstAttempt;
-        }
-
-        @Override
-        public R get() throws ExecutionException {
-            throw e;
-        }
-
-        @Override
-        public boolean hasResult() {
-            return false;
-        }
-
-        @Override
-        public boolean hasException() {
-            return true;
-        }
-
-        @Override
-        public R getResult() throws IllegalStateException {
-            throw new IllegalStateException("The attempt resulted in an exception, not in a result");
-        }
-
-        @Override
-        public Throwable getExceptionCause() throws IllegalStateException {
-            return e.getCause();
-        }
-
-        @Override
-        public long getAttemptNumber() {
-            return attemptNumber;
-        }
-
-        @Override
-        public long getDelaySinceFirstAttempt() {
-            return delaySinceFirstAttempt;
-        }
     }
 
     /**

--- a/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
+++ b/src/test/java/com/github/rholder/retry/StopStrategiesTest.java
@@ -52,6 +52,6 @@ public class StopStrategiesTest {
     }
 
     public Attempt<Boolean> failedAttempt(long attemptNumber, long delaySinceFirstAttempt) {
-        return new Retryer.ExceptionAttempt<Boolean>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
+        return new ExceptionAttempt<Boolean>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
     }
 }

--- a/src/test/java/com/github/rholder/retry/WaitStrategiesTest.java
+++ b/src/test/java/com/github/rholder/retry/WaitStrategiesTest.java
@@ -169,11 +169,11 @@ public class WaitStrategiesTest {
     }
 
     public Attempt<Boolean> failedAttempt(long attemptNumber, long delaySinceFirstAttempt) {
-        return new Retryer.ExceptionAttempt<Boolean>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
+        return new ExceptionAttempt<Boolean>(new RuntimeException(), attemptNumber, delaySinceFirstAttempt);
     }
 
     public Attempt<Boolean> failedRetryAfterAttempt(long attemptNumber, long delaySinceFirstAttempt) {
-        return new Retryer.ExceptionAttempt<Boolean>(new RetryAfterException(), attemptNumber, delaySinceFirstAttempt);
+        return new ExceptionAttempt<Boolean>(new RetryAfterException(), attemptNumber, delaySinceFirstAttempt);
     }
 
     public Function<RuntimeException, Long> zeroSleepFunction() {


### PR DESCRIPTION
I'm in (much belated) process of upgrading my company's codebase to `2.0.0`. In doing so, I found that I had to copy-past these class definitions into our code in order to use them, so I thought that they'd be useful to expose.

I think that it could also make sense to demote these back to static classes and expose via factory methods:
```java
public class Attempts {
  public static <R> Attempt<R> exceptionAttempt(Throwable cause, long attemptNumber, long delaySinceFirstAttempt) {
    return new ExceptionAttempt<R>(cause, attemptNumber, delaySinceFirstAttempt);
  }

  public static <R> Attempt<R> resultAttempt(R result, long attemptNumber, long delaySinceFirstAttempt) {
    return new ResultAttempt<R>(result, attemptNumber, delaySinceFirstAttempt);
  }
}
```

Let me know what you think: I'll happily iterate on this as desired!

@rholder 