### PR TITLE
Fix dependency on Guava.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:[10.+,)'
+    compile 'com.google.guava:guava:[10.+,21.+)'
     compile 'com.google.code.findbugs:jsr305:2.0.2'
 
     // junit testing


### PR DESCRIPTION
The build currently breaks when compiled against Guava 23. This fixes the open-ended dependency so it obeys semantic versioning.

Fixes #1