### PR TITLE
Printing error when the number of retries is 0

### DIFF
--- a/src/main/java/com/github/rholder/retry/StopStrategies.java
+++ b/src/main/java/com/github/rholder/retry/StopStrategies.java
@@ -100,7 +100,7 @@ public final class StopStrategies {
         private final int maxAttemptNumber;
 
         public StopAfterAttemptStrategy(int maxAttemptNumber) {
-            Preconditions.checkArgument(maxAttemptNumber >= 1, "maxAttemptNumber must be >= 1 but is %d", maxAttemptNumber);
+            Preconditions.checkArgument(maxAttemptNumber >= 1, "maxAttemptNumber must be >= 1 but is %s", maxAttemptNumber);
             this.maxAttemptNumber = maxAttemptNumber;
         }
 


### PR DESCRIPTION
An exception will be thrown when `StopStrategies.stopAfterAttempt` is set to 0.
```java
Exception in thread "main" java.lang.IllegalArgumentException: maxAttemptNumber must be >= 1 but is %d [0]
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:190)
```
It should be
```java
Exception in thread "main" java.lang.IllegalArgumentException: maxAttemptNumber must be >= 1 but is 0
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:190)
```