### PR TITLE
Not calling Thread.sleep() if sleepTime is Zero #1

### DIFF
--- a/src/main/java/com/github/rholder/retry/BlockStrategies.java
+++ b/src/main/java/com/github/rholder/retry/BlockStrategies.java
@@ -43,7 +43,7 @@ public final class BlockStrategies {
 
         @Override
         public void block(long sleepTime) throws InterruptedException {
-            if (sleepTime == 0L){
+            if (sleepTime == 0L) {
                 return;
             }
             Thread.sleep(sleepTime);

--- a/src/main/java/com/github/rholder/retry/BlockStrategies.java
+++ b/src/main/java/com/github/rholder/retry/BlockStrategies.java
@@ -43,6 +43,9 @@ public final class BlockStrategies {
 
         @Override
         public void block(long sleepTime) throws InterruptedException {
+            if (sleepTime == 0L){
+                return;
+            }
             Thread.sleep(sleepTime);
         }
     }


### PR DESCRIPTION
Zero `sleepTime` implies there is no need to sleep and hence call to Thread.sleep() is redundant